### PR TITLE
Allows the Frontier Vending Equipment Restock to be purchasable via cargo

### DIFF
--- a/code/modules/cargo/packs/vendor_refill.dm
+++ b/code/modules/cargo/packs/vendor_refill.dm
@@ -44,3 +44,10 @@
 	cost = 1000
 	contains = list(/obj/item/vending_refill/games)
 	crate_name = "games supply crate"
+
+/datum/supply_pack/vendor_refill/mining_equipment
+	name = "Frontier Supply Crate"
+	desc = "Restock your favourite frontier vending machine with all of your favourite mining equipment."
+	cost = 4000
+	contains = list(/obj/item/vending_refill/mining_equipment)
+	crate_name = "frontier supply crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Frontier equipment vending machines can now actually be built and used.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
mining good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added new things
add: Added more things
del: Removed old things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
