### PR TITLE
Plasmamen Tank Spawn Location Changed (QoL)

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -150,7 +150,7 @@
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	uniform = /obj/item/clothing/under/plasmaman
-	r_hand= /obj/item/tank/internals/plasmaman/belt/full
+	r_pocket = /obj/item/tank/internals/plasmaman/belt/full
 	mask = /obj/item/clothing/mask/breath
 	gloves = /obj/item/clothing/gloves/color/plasmaman
 


### PR DESCRIPTION
QoL update for Plasmamen (Phorid) where their plasma internals tank now spawns in their right pocket instead of their right hand. 

This means that you can instantly turn it on rather than scramble to pick it up and turn it on... or forget it is there entirely.