### PR TITLE
dark mode readable blue health analyzers

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -226,12 +226,12 @@ GENE SCANNER
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
 			var/dmgreport = "<span class='info ml-1'>General status:</span>\
 							<table class='ml-2'><tr><font face='Verdana'>\
-							<td style='width:7em;'><font color='#0000CC'>Damage:</font></td>\
+							<td style='width:7em;'><font color='#0d5cee'>Damage:</font></td>\
 							<td style='width:5em;'><font color='red'><b>Brute</b></font></td>\
 							<td style='width:4em;'><font color='orange'><b>Burn</b></font></td>\
 							<td style='width:4em;'><font color='green'><b>Toxin</b></font></td>\
 							<td style='width:8em;'><font color='purple'><b>Suffocation</b></font></td></tr>\
-							<tr><td><font color='#0000CC'>Overall:</font></td>\
+							<tr><td><font color='#1d63e6'>Overall:</font></td>\
 							<td><font color='red'>[CEILING(brute_loss,1)]</font></td>\
 							<td><font color='orange'>[CEILING(fire_loss,1)]</font></td>\
 							<td><font color='green'>[CEILING(tox_loss,1)]</font></td>\
@@ -239,7 +239,7 @@ GENE SCANNER
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
-				dmgreport += "<tr><td><font color='#0000CC'>[capitalize(parse_zone(org.body_zone))]:</font></td>\
+				dmgreport += "<tr><td><font color='#1d63e6'>[capitalize(parse_zone(org.body_zone))]:</font></td>\
 								<td><font color='red'>[(org.brute_dam > 0) ? "[CEILING(org.brute_dam,1)]" : "0"]</font></td>\
 								<td><font color='orange'>[(org.burn_dam > 0) ? "[CEILING(org.burn_dam,1)]" : "0"]</font></td></tr>"
 			dmgreport += "</font></table>"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -122,8 +122,8 @@ GENE SCANNER
 		user.visible_message("<span class='warning'>[user] analyzes the floor's vitals!</span>", \
 							"<span class='notice'>You stupidly try to analyze the floor's vitals!</span>")
 		to_chat(user, "<span class='info'>Analyzing results for The floor:\n\tOverall status: <b>Healthy</b></span>\
-					\n<span class='info'>Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FF8000'>Burn</font>/<font color='red'>Brute</font></span>\
-					\n<span class='info'>\tDamage specifics: <font color='blue'>0</font>-<font color='green'>0</font>-<font color='#FF8000'>0</font>-<font color='red'>0</font></span>\
+					\n<span class='info'>Key: <font color='#1d63e6'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FF8000'>Burn</font>/<font color='red'>Brute</font></span>\
+					\n<span class='info'>\tDamage specifics: <font color='#1d63e6'>0</font>-<font color='green'>0</font>-<font color='#FF8000'>0</font>-<font color='red'>0</font></span>\
 					\n<span class='info'>Body temperature: ???</span>")
 		return
 
@@ -235,7 +235,7 @@ GENE SCANNER
 							<td><font color='red'>[CEILING(brute_loss,1)]</font></td>\
 							<td><font color='orange'>[CEILING(fire_loss,1)]</font></td>\
 							<td><font color='green'>[CEILING(tox_loss,1)]</font></td>\
-							<td><font color='blue'>[CEILING(oxy_loss,1)]</font></td></tr>"
+							<td><font color='#1d63e6'>[CEILING(oxy_loss,1)]</font></td></tr>"
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
@@ -290,9 +290,9 @@ GENE SCANNER
 			var/render = FALSE
 			var/toReport = "<span class='info ml-1'>Organs:</span>\
 				<table class='ml-2'><tr>\
-				<td style='width:6em;'><font color='#0000CC'><b>Organ</b></font></td>\
-				[advanced ? "<td style='width:3em;'><font color='#0000CC'><b>Dmg</b></font></td>" : ""]\
-				<td style='width:12em;'><font color='#0000CC'><b>Status</b></font></td>"
+				<td style='width:6em;'><font color='#0d5cee'><b>Organ</b></font></td>\
+				[advanced ? "<td style='width:3em;'><font color='#0d5cee'><b>Dmg</b></font></td>" : ""]\
+				<td style='width:12em;'><font color='#0d5cee'><b>Status</b></font></td>"
 
 			for(var/obj/item/organ/organ in H.internal_organs)
 				var/status = ""
@@ -301,8 +301,8 @@ GENE SCANNER
 				else if (organ.damage > organ.low_threshold) status = "<font color='#F28F1F'>Mildly Damaged</font>"
 				if (status != "")
 					render = TRUE
-					toReport += "<tr><td><font color='#0000CC'>[organ.name]</font></td>\
-						[advanced ? "<td><font color='#0000CC'>[CEILING(organ.damage,1)]</font></td>" : ""]\
+					toReport += "<tr><td><font color='#0d5cee'>[organ.name]</font></td>\
+						[advanced ? "<td><font color='#0d5cee'>[CEILING(organ.damage,1)]</font></td>" : ""]\
 						<td>[status]</td></tr>"
 
 			if (render)


### PR DESCRIPTION
space: Cherry-picking commits from shiptest proper that I like

Also changes the blue for oxy damage as I like to read in darkmode

***

…le by dark mode users (#3411)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This tweaks the color of body part lists as given by health analyzers, in an effort to enhance readability for dark mode users.

### Before the change:
| Dark Mode |
|-----------|

|![image](https://github.com/user-attachments/assets/95d5fe3e-d565-4eec-be40-4ba6b58211ec)|

| Light Mode |
|------------|

|![image](https://github.com/user-attachments/assets/45376b28-785b-40c3-9cdc-fecc49ecacaf)|


### After the change:
| Dark Mode |
|-----------|

|![dreamseeker_vtOyuEpuir](https://github.com/user-attachments/assets/756b0163-99b9-4341-9420-07ded5cc07cf)|

| Light Mode |
|------------|

|![image](https://github.com/user-attachments/assets/52b3d45d-5a57-4396-8e7f-81a976222e77)|

## Why It's Good For The Game

This should make it easier for dark mode users to know, at a glance, what body parts might be damaged on a patient. As it stands right now, one would have to highlight the text in order to see which limb(s) have been damaged.