### PR TITLE
Miskilamo Style Consistency (#3377)

### DIFF
--- a/_maps/configs/independent_kilo.json
+++ b/_maps/configs/independent_kilo.json
@@ -13,7 +13,7 @@
 		"NATURAL"
 	],
 	"map_short_name": "Kilo-class",
-	"starting_funds": 3500,
+	"starting_funds": 1500,
 	"map_path": "_maps/shuttles/independent/independent_kilo.dmm",
 	"job_slots": {
 		"Captain": {

--- a/_maps/configs/independent_mudskipper.json
+++ b/_maps/configs/independent_mudskipper.json
@@ -19,7 +19,7 @@
 	"starting_funds": 1500,
 	"job_slots": {
 		"Salvage Leader": {
-			"outfit": "/datum/outfit/job/independent/captain",
+			"outfit": "/datum/outfit/job/independent/captain/cheap",
 			"officer": true,
 			"slots": 1
 		},

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -7,22 +7,20 @@
 /area/ship/cargo)
 "ak" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/hull,
 /area/ship/engineering)
 "am" = (
 /obj/machinery/autolathe,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "ar" = (
 /obj/machinery/atmospherics/components/unary/shuttle/heater,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "kilothrusters"
 	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering)
@@ -37,7 +35,8 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/table_frame,
 /obj/item/shard,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "ay" = (
 /obj/effect/decal/cleanable/glass,
@@ -60,40 +59,31 @@
 /obj/structure/cable/pink{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/port)
 "aJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
 /obj/structure/chair/bench/olive/directional/east,
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "aS" = (
-/obj/effect/turf_decal/borderfloor,
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/secure_closet/engineering_personal{
-	populate = 0;
-	anchored = 1
+	anchored = 1;
+	populate = 0
 	},
 /obj/item/storage/backpack/industrial,
 /obj/item/clothing/under/rank/engineering/engineer,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/shoes/workboots,
 /obj/item/clothing/head/hardhat/dblue,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "aU" = (
 /obj/structure/cable/cyan{
@@ -104,20 +94,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "aZ" = (
 /obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#E3994E"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "bg" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -132,8 +113,8 @@
 	pixel_x = -5
 	},
 /obj/machinery/light_switch{
-	pixel_x = 5;
 	dir = 1;
+	pixel_x = 5;
 	pixel_y = -19
 	},
 /turf/open/floor/plating,
@@ -147,15 +128,14 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/shuttle/engine/electric,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/hull,
 /area/ship/engineering)
 "by" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bA" = (
 /obj/structure/chair/plastic,
@@ -163,16 +143,13 @@
 	icon_state = "4-6"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/beer{
-	pixel_y = 5;
+	list_reagents = null;
 	pixel_x = -14;
-	list_reagents = null
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "bF" = (
 /turf/closed/wall,
@@ -191,19 +168,15 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bH" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 1
-	},
 /obj/machinery/firealarm/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "bL" = (
 /obj/structure/cable/pink{
@@ -216,7 +189,6 @@
 /obj/structure/extinguisher_cabinet/directional/east{
 	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "bM" = (
@@ -242,7 +214,7 @@
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "bT" = (
@@ -255,8 +227,7 @@
 /obj/structure/cable/pink{
 	icon_state = "4-9"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bU" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -299,16 +270,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "bY" = (
 /obj/structure/cable/pink{
@@ -320,8 +289,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "bZ" = (
 /obj/structure/closet/crate/secure/exo,
@@ -336,11 +304,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ca" = (
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -352,33 +318,28 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -19;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -19
 	},
 /obj/structure/extinguisher_cabinet/directional/south{
 	pixel_x = -6
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "cb" = (
-/obj/effect/turf_decal/borderfloor,
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "cf" = (
 /obj/machinery/door/poddoor{
 	id = "kilocargo"
 	},
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
-	id = "kilofield";
-	dir = 8
+	dir = 8;
+	id = "kilofield"
 	},
 /obj/structure/cable/pink{
 	icon_state = "0-10"
@@ -427,7 +388,8 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
 "cq" = (
 /turf/closed/wall,
@@ -437,7 +399,8 @@
 /obj/structure/cable/pink{
 	icon_state = "0-10"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "cw" = (
 /obj/structure/table/wood,
@@ -448,20 +411,16 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/food/drinks/beer{
-	pixel_y = 7;
+	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 10);
 	pixel_x = -6;
-	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 10)
+	pixel_y = 7
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#E3994E"
-	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "cB" = (
 /obj/structure/closet/secure_closet/miner{
-	populate = 0;
-	anchored = 1
+	anchored = 1;
+	populate = 0
 	},
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
@@ -505,7 +464,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/mono,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "cJ" = (
 /obj/structure/chair/handrail{
@@ -513,12 +473,6 @@
 	},
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = -21
-	},
-/obj/effect/decal/cleanable/crayon{
-	icon_state = "space";
-	pixel_y = 2;
-	pixel_x = 6;
-	paint_colour = "#FF0000"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable/pink{
@@ -529,14 +483,15 @@
 	pixel_x = -19;
 	pixel_y = 13
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance/fore)
 "cK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "cM" = (
 /obj/structure/cable/pink{
@@ -545,25 +500,21 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/pink{
 	icon_state = "6-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "cP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating/airless,
 /area/ship/hallway/port)
 "cV" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable/pink{
 	icon_state = "2-9"
 	},
@@ -571,20 +522,23 @@
 	icon_state = "2-5"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "cW" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/structure/sink/kitchen{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 20;
 	pixel_y = -12
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "cY" = (
 /obj/structure/cable/pink{
@@ -594,22 +548,18 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "cZ" = (
 /obj/machinery/power/ship_gravity,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "da" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "dc" = (
 /obj/item/kirbyplants/fullysynthetic{
@@ -619,17 +569,15 @@
 	icon_state = "0-1"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/item/stack/tile/plasteel{
-	pixel_x = 7;
-	pixel_y = -8
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/vomit/old{
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "de" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Cryogenics"
-	},
 /obj/structure/cable/pink{
 	icon_state = "2-9"
 	},
@@ -637,15 +585,19 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock{
+	dir = 1;
+	name = "Cryo Room"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "dt" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "dF" = (
 /obj/effect/turf_decal/miskilamo_small/right{
@@ -654,7 +606,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "eo" = (
 /obj/machinery/power/port_gen/pacman{
@@ -663,15 +615,9 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "eN" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/crate_shelf,
 /turf/open/floor/plasteel/patterned/grid,
@@ -683,11 +629,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "fu" = (
 /obj/effect/turf_decal/corner/opaque/black/mono,
@@ -700,11 +642,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "gp" = (
 /obj/structure/closet/wall/blue/directional/north{
@@ -727,10 +665,9 @@
 /obj/structure/cable/pink{
 	icon_state = "4-10"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "gs" = (
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/cable/pink{
 	icon_state = "4-10"
 	},
@@ -745,6 +682,7 @@
 	dir = 6
 	},
 /obj/item/cigbutt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "gC" = (
@@ -759,15 +697,15 @@
 /obj/structure/table,
 /obj/machinery/light/small/directional/west,
 /obj/item/clothing/glasses/welding{
-	pixel_y = -9;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = -9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "hh" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "hN" = (
 /obj/machinery/mineral/processing_unit{
@@ -785,8 +723,8 @@
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "hS" = (
 /obj/structure/chair/sofa/brown/old/left/directional/east,
@@ -797,12 +735,8 @@
 	dir = 5
 	},
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#E3994E"
-	},
 /obj/effect/decal/cleanable/confetti,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -811,11 +745,10 @@
 	pixel_x = 17
 	},
 /obj/item/reagent_containers/glass/bucket{
+	list_reagents = list(/datum/reagent/water = 20);
 	pixel_x = 8;
-	pixel_y = 7;
-	list_reagents = list(/datum/reagent/water = 20)
+	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "im" = (
@@ -844,43 +777,41 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel/mono,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "iM" = (
 /obj/structure/cable/pink{
 	icon_state = "2-6"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 5
-	},
 /obj/structure/chair/bench/beige/directional/east{
 	dir = 8
 	},
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "iT" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/food/flour,
 /mob/living/simple_animal/hostile/cockroach,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "jl" = (
 /obj/machinery/mineral/processing_unit_console{
-	pixel_y = 0;
+	dir = 8;
+	machinedir = 1;
 	output_dir = 4;
 	pixel_x = 20;
-	dir = 8;
-	machinedir = 1
+	pixel_y = 0
 	},
-/obj/effect/turf_decal/industrial/warning/corner,
 /obj/effect/turf_decal/corner_techfloor_grid{
 	dir = 5
 	},
@@ -889,8 +820,8 @@
 /area/ship/cargo)
 "jx" = (
 /obj/machinery/conveyor{
-	id = "kiloconveyor";
-	dir = 4
+	dir = 4;
+	id = "kiloconveyor"
 	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -905,16 +836,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -19;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = -19
 	},
 /obj/structure/cable/pink{
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "jU" = (
@@ -940,11 +871,14 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance/fore)
 "kA" = (
 /turf/closed/wall/r_wall,
 /area/ship/engineering)
+"lw" = (
+/turf/closed/wall/rust,
+/area/ship/bridge)
 "mr" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/eva,
@@ -953,16 +887,16 @@
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
 /obj/effect/turf_decal/box/corners,
 /obj/structure/cable/pink{
 	icon_state = "1-5"
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
@@ -974,7 +908,6 @@
 	pixel_y = 20
 	},
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "nd" = (
@@ -984,14 +917,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/cable/pink{
 	icon_state = "8-9"
 	},
 /obj/structure/cable/pink{
 	icon_state = "1-5"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ng" = (
 /obj/structure/cable/pink{
@@ -1001,7 +933,6 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/glass,
 /obj/structure/cable/pink{
 	icon_state = "4-5"
 	},
@@ -1009,28 +940,28 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "nJ" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/machinery/button/door{
+	dir = 4;
 	id = "kilocargo";
 	name = "blast door control";
 	pixel_x = -20;
-	pixel_y = 7;
-	dir = 4
+	pixel_y = 7
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 4;
-	pixel_y = -2;
+	id = "kilofield";
 	pixel_x = -19;
-	id = "kilofield"
+	pixel_y = -2
 	},
 /obj/item/clothing/head/cone{
-	pixel_y = 4;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "nO" = (
 /turf/closed/wall/r_wall,
@@ -1039,6 +970,7 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden,
 /obj/machinery/cell_charger,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "oP" = (
@@ -1048,18 +980,18 @@
 	},
 /obj/item/stack/sheet/mineral/plasma/ten,
 /obj/item/reagent_containers/food/drinks/beer{
-	pixel_y = 11;
+	list_reagents = null;
 	pixel_x = -13;
-	list_reagents = null
+	pixel_y = 11
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "pV" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "kiloconveyor";
+	layer = 3.09;
 	pixel_x = 11;
-	pixel_y = 14;
-	layer = 3.09
+	pixel_y = 14
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid,
@@ -1069,7 +1001,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/maintenance/fore)
 "qw" = (
 /obj/machinery/door/airlock/external{
@@ -1079,7 +1012,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/maintenance/fore)
 "rc" = (
 /obj/structure/catwalk/over/plated_catwalk,
@@ -1123,7 +1057,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "rW" = (
 /turf/closed/wall/yesdiag,
@@ -1154,22 +1089,31 @@
 /obj/structure/cable/pink{
 	icon_state = "6-10"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "sW" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 1
-	},
 /obj/machinery/computer/cargo/retro{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
+"tb" = (
+/turf/closed/wall/rust,
+/area/ship/crew/dorm)
+"tW" = (
+/turf/closed/wall/rust,
+/area/ship/crew)
+"vl" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/hallway/port)
 "vv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
@@ -1178,8 +1122,7 @@
 /obj/structure/cable/pink{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "wc" = (
 /obj/structure/table/wood,
@@ -1190,13 +1133,13 @@
 	pixel_y = 22
 	},
 /obj/item/reagent_containers/food/snacks/sandwich{
-	pixel_y = 9;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 9
 	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "wh" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/rust,
 /area/ship/crew/dorm)
 "xe" = (
 /obj/machinery/door/airlock/external/glass{
@@ -1211,10 +1154,14 @@
 /obj/structure/cable/pink{
 	icon_state = "6-10"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/maintenance/fore)
 "xk" = (
 /turf/closed/wall,
+/area/ship/hallway/central)
+"xn" = (
+/turf/closed/wall/rust,
 /area/ship/hallway/central)
 "xF" = (
 /obj/structure/cable/pink{
@@ -1227,14 +1174,9 @@
 	pixel_x = 11
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#E3994E"
-	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "yd" = (
-/obj/structure/catwalk/over/plated_catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -1244,10 +1186,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "yn" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/structure/closet/secure_closet/freezer/fridge{
 	populate = 0
 	},
@@ -1272,15 +1214,14 @@
 /obj/effect/spawner/lootdrop/ration,
 /obj/item/reagent_containers/food/snacks/icecreamsandwich,
 /obj/item/reagent_containers/food/snacks/icecreamsandwich,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "yF" = (
 /turf/closed/wall/r_wall,
 /area/ship/crew)
 "zc" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 8
-	},
 /obj/structure/curtain,
 /obj/machinery/shower{
 	dir = 1
@@ -1291,6 +1232,9 @@
 /obj/item/bikehorn/rubberducky/plasticducky{
 	pixel_x = -9;
 	pixel_y = -7
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 6
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew)
@@ -1311,22 +1255,22 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock{
-	name = "Dormitory";
+	dir = 8;
+	name = "Dormitory"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#E3994E";
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#E3994E"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#E3994E"
+	color = "#E3994E";
+	dir = 4
 	},
 /turf/open/floor/wood/yew,
 /area/ship/crew)
 "AB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "AE" = (
 /obj/structure/closet/cabinet,
@@ -1340,11 +1284,8 @@
 /obj/structure/cable/pink{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#E3994E"
-	},
-/turf/open/floor/wood/yew,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "AP" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -1353,8 +1294,7 @@
 	target_pressure = 500
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "AQ" = (
 /turf/closed/wall,
@@ -1370,18 +1310,13 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Bm" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Bu" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -1390,24 +1325,23 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/effect/turf_decal/borderfloor/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "BS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor{
-	id = "kilobridge";
-	dir = 4
+	dir = 4;
+	id = "kilobridge"
 	},
 /turf/open/floor/plating/airless,
 /area/ship/bridge)
+"Ce" = (
+/turf/closed/wall/rust,
+/area/ship/maintenance/fore)
 "Co" = (
 /obj/machinery/door/poddoor{
 	id = "kilocargo"
@@ -1431,17 +1365,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/medical,
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/storage/firstaid/regular,
 /obj/item/roller,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Da" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Ds" = (
 /obj/structure/filingcabinet/chestdrawer{
@@ -1456,7 +1388,11 @@
 /obj/structure/cable/pink{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "Ew" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1466,8 +1402,8 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -19;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -19
 	},
 /obj/structure/catwalk/over/plated_catwalk,
 /obj/structure/cable/pink{
@@ -1477,7 +1413,6 @@
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "EG" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
@@ -1485,24 +1420,23 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/confetti,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "EU" = (
 /obj/structure/cable/pink{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/vomit/old{
-	pixel_x = -5
-	},
 /obj/item/cigbutt,
 /obj/machinery/computer/cryopod/retro/directional/west,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "GK" = (
 /obj/structure/table,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 20
@@ -1534,7 +1468,10 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "HP" = (
 /obj/item/kirbyplants/fullysynthetic{
@@ -1546,20 +1483,16 @@
 /obj/machinery/firealarm/directional/east{
 	pixel_y = -5
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#E3994E"
-	},
 /obj/effect/decal/cleanable/confetti,
 /obj/item/cigbutt,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Ih" = (
 /obj/structure/cable/pink{
 	icon_state = "1-6"
 	},
 /obj/structure/ore_box,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Jf" = (
 /turf/closed/wall/r_wall,
@@ -1586,13 +1519,10 @@
 /area/ship/maintenance/fore)
 "KM" = (
 /obj/machinery/atmospherics/components/binary/valve/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/oil/streak,
 /obj/item/cigbutt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "KR" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -1601,20 +1531,17 @@
 /obj/structure/cable/pink{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/borderfloor,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "La" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/item/clothing/head/cone{
-	pixel_y = 4;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east{
 	pixel_y = 7
@@ -1623,7 +1550,10 @@
 	pixel_y = -5
 	},
 /obj/item/cigbutt,
-/turf/open/floor/plasteel/patterned/grid,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "LC" = (
 /obj/structure/cable/cyan{
@@ -1632,11 +1562,7 @@
 /obj/structure/cable/pink{
 	icon_state = "2-5"
 	},
-/obj/effect/turf_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "Mj" = (
 /obj/machinery/mineral/unloading_machine,
@@ -1648,24 +1574,22 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/shuttle,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "kilothrusters"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
 "MY" = (
 /obj/structure/chair/sofa/brown/old/corner/directional/north,
 /obj/structure/sign/poster/random{
-	pixel_y = 0;
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
-/obj/effect/decal/cleanable/vomit/old{
-	pixel_x = -5
-	},
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Ng" = (
 /obj/structure/cable/pink{
@@ -1691,17 +1615,18 @@
 /turf/closed/wall/r_wall/yesdiag,
 /area/ship/cargo)
 "NB" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 8;
-	name = "Bathroom"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/patterned/brushed,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Restroom"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "NI" = (
 /obj/structure/sink{
@@ -1722,21 +1647,18 @@
 	pixel_x = -12;
 	pixel_y = 20
 	},
-/obj/effect/decal/cleanable/greenglow,
 /obj/item/storage/pill_bottle/happy{
 	pixel_x = 12;
 	pixel_y = 12
 	},
 /mob/living/simple_animal/hostile/cockroach,
-/turf/open/floor/plasteel/patterned/brushed,
+/obj/effect/decal/cleanable/vomit/old{
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew)
 "NT" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "NU" = (
 /obj/structure/table/wood,
@@ -1750,8 +1672,8 @@
 	pixel_y = 3
 	},
 /obj/structure/sign/poster/random{
-	pixel_y = 0;
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
@@ -1772,19 +1694,32 @@
 /obj/structure/cable/pink{
 	icon_state = "2-10"
 	},
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
+"OQ" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/engineering)
 "Pg" = (
 /obj/machinery/computer/helm/retro{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
+"PJ" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/cargo)
 "PS" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "PW" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -1796,7 +1731,7 @@
 "Rq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
@@ -1809,36 +1744,36 @@
 	dir = 6
 	},
 /obj/machinery/button/door{
-	pixel_y = 20;
-	pixel_x = -6;
 	id = "kilowindows";
-	name = "Window Lockdown"
+	name = "Window Lockdown";
+	pixel_x = -6;
+	pixel_y = 20
 	},
 /obj/machinery/button/door{
-	pixel_y = 20;
-	pixel_x = 6;
 	id = "kilobridge";
-	name = "Bridge Lockdown"
+	name = "Bridge Lockdown";
+	pixel_x = 6;
+	pixel_y = 20
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/pink{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Sx" = (
-/obj/effect/turf_decal/corner/opaque/red/diagonal,
 /obj/structure/table/reinforced,
 /obj/item/cutting_board{
 	anchored = 1
 	},
 /obj/item/kitchen/knife,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "Ti" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
@@ -1850,7 +1785,6 @@
 	},
 /obj/item/bedsheet/dorms,
 /obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
 "To" = (
@@ -1861,31 +1795,40 @@
 	icon_state = "0-6"
 	},
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
-	id = "kilofield";
-	dir = 4
+	dir = 4;
+	id = "kilofield"
 	},
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
+"Tr" = (
+/turf/closed/wall/rust,
+/area/ship/engineering)
 "TD" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table/reinforced,
 /obj/item/megaphone/cargo{
-	pixel_y = 5;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 5
 	},
 /obj/item/cigbutt{
-	pixel_y = 5;
-	pixel_x = -17
+	pixel_x = -17;
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "TG" = (
 /turf/closed/wall,
 /area/ship/hallway/port)
+"TY" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/bridge)
 "Ua" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
@@ -1896,24 +1839,23 @@
 "Un" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/shutters{
 	id = "kilowindows"
 	},
 /turf/open/floor/plating/airless,
 /area/ship/hallway/port)
 "Uv" = (
 /obj/docking_port/stationary{
-	width = 30;
-	height = 15;
+	dir = 4;
 	dwidth = 15;
-	dir = 4
+	height = 15;
+	width = 30
 	},
 /turf/template_noop,
 /area/template_noop)
 "UY" = (
 /obj/structure/chair/sofa/brown/old/right/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Va" = (
 /obj/structure/closet/crate/secure/weapon,
@@ -1929,7 +1871,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/item/ammo_box/a12g,
 /obj/item/gun/ballistic/shotgun/doublebarrel/no_mag,
-/turf/open/floor/plasteel/patterned/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Vd" = (
 /obj/structure/cable/pink{
@@ -1942,28 +1884,27 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/east{
 	pixel_y = 8
 	},
-/obj/machinery/firealarm/directional/east{
-	pixel_y = -2
-	},
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
+/obj/machinery/button/door{
+	dir = 8;
+	id = "amogusthrusters";
+	name = "Thruster Lockdown";
+	pixel_x = 21
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "Vh" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8;
 	piping_layer = 2
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Vq" = (
 /turf/closed/wall/r_wall/yesdiag,
@@ -1972,14 +1913,13 @@
 /obj/effect/turf_decal/miskilamo_small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "Vx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
 /turf/open/floor/carpet,
 /area/ship/crew/dorm)
@@ -1987,7 +1927,7 @@
 /obj/effect/turf_decal/miskilamo_small/left{
 	dir = 1
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "We" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -2011,30 +1951,35 @@
 "Xd" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
-	pixel_y = 4;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 4
 	},
 /obj/item/pen/fourcolor,
 /obj/machinery/airalarm/directional/south,
 /obj/item/radio/intercom/wideband/directional/west,
 /obj/item/reagent_containers/food/drinks/coffee{
-	pixel_y = 7;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "XQ" = (
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/central)
 "XR" = (
 /turf/closed/wall,
+/area/ship/crew)
+"Yn" = (
+/turf/closed/wall/r_wall/rust,
 /area/ship/crew)
 "Yu" = (
 /obj/structure/grille,
@@ -2047,10 +1992,11 @@
 	dir = 1
 	},
 /obj/item/reagent_containers/food/drinks/beer{
-	pixel_y = 12;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 12
 	},
-/turf/open/floor/wood/yew,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "YL" = (
 /obj/structure/chair/sofa/brown/old/directional/east,
@@ -2058,7 +2004,7 @@
 	dir = 5
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "ZC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2067,12 +2013,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5;
-	color = "#E3994E"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/yew,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "ZG" = (
 /obj/structure/cable/pink{
@@ -2092,7 +2033,7 @@ AQ
 bn
 bn
 bn
-AQ
+Tr
 ak
 AQ
 aa
@@ -2101,7 +2042,7 @@ aa
 (2,1,1) = {"
 aa
 aa
-kA
+OQ
 ar
 kA
 MI
@@ -2179,7 +2120,7 @@ aa
 Ua
 aS
 ca
-cq
+tb
 cq
 cq
 cq
@@ -2191,7 +2132,7 @@ aa
 (8,1,1) = {"
 aa
 aa
-Jf
+vl
 TG
 cC
 cq
@@ -2228,7 +2169,7 @@ XR
 XR
 zH
 XR
-XR
+tW
 XR
 yF
 aa
@@ -2288,10 +2229,10 @@ Ud
 XR
 XR
 rO
-XR
+tW
 NB
 XR
-yF
+Yn
 "}
 (15,1,1) = {"
 Nq
@@ -2303,7 +2244,7 @@ cB
 im
 dt
 sD
-xk
+xn
 NI
 zc
 yF
@@ -2365,7 +2306,7 @@ GM
 jK
 bF
 bF
-bF
+lw
 bP
 "}
 (20,1,1) = {"
@@ -2385,7 +2326,7 @@ bP
 "}
 (21,1,1) = {"
 aa
-ac
+PJ
 hN
 jl
 OH
@@ -2417,11 +2358,11 @@ aa
 aa
 KB
 bm
-KB
+Ce
 kb
 cJ
-bP
-bP
+TY
+TY
 BS
 BS
 BS

--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -1765,7 +1765,7 @@
 /obj/item/cutting_board{
 	anchored = 1
 	},
-/obj/item/kitchen/knife,
+/obj/item/melee/knife/kitchen,
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /turf/open/floor/plasteel,

--- a/_maps/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/shuttles/independent/independent_mudskipper.dmm
@@ -9,7 +9,7 @@
 	icon_state = "0-1"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "ag" = (
 /obj/machinery/power/shuttle/engine/electric{
@@ -18,45 +18,33 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull,
 /area/ship/engineering/engine)
 "ak" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 8;
-	color = "#543C30"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ao" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "Plasma to Engines";
-	dir = 1
+	dir = 1;
+	name = "Plasma to Engines"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
@@ -70,70 +58,51 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "bS" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
-"bZ" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/door/window/eastleft{
-	layer = 3.1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "mudskipper_engine"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "cn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair/handrail,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "cs" = (
 /turf/template_noop,
 /area/template_noop)
 "cx" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/effect/turf_decal/miskilamo_small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-10"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "cB" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -141,46 +110,42 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "4-9"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet,
 /area/ship/crew)
 "dc" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/hallway/central)
 "dw" = (
 /obj/structure/window/reinforced/spawner,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/machinery/button/door{
 	dir = 8;
-	pixel_x = 22;
-	pixel_y = 15;
 	id = "mudskipper_engine";
-	name = "Engine Shutters"
+	name = "Engine Shutters";
+	pixel_x = 22;
+	pixel_y = 15
 	},
 /obj/machinery/cell_charger,
 /obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "dN" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/transparent/neutral,
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "dQ" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -192,8 +157,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/grimy,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/turf/open/floor/carpet,
 /area/ship/crew)
 "dT" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -207,41 +174,46 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "dZ" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/glass,
 /obj/structure/extinguisher_cabinet/directional/west{
 	pixel_y = 5
 	},
 /obj/machinery/button/door{
 	dir = 4;
-	pixel_x = -33;
-	pixel_y = -7;
 	id = "mudskipper_door";
-	name = "Cargo Door"
+	name = "Cargo Door";
+	pixel_x = -33;
+	pixel_y = -7
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 4;
-	pixel_x = -21;
-	pixel_y = -7;
 	id = "mudskipper_shield";
-	name = "Cargo Holofield"
+	name = "Cargo Holofield";
+	pixel_x = -21;
+	pixel_y = -7
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "2-10"
+	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ec" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "ee" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -250,19 +222,15 @@
 	},
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/plasteel/tech/airless,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "en" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "eu" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/structure/railing{
 	dir = 8
 	},
@@ -274,8 +242,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
+"ev" = (
+/turf/closed/wall,
+/area/ship/crew/cryo)
 "eL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -283,21 +255,18 @@
 /obj/structure/sign/poster/contraband/smoke{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 4
-	},
 /obj/item/toy/cards/deck{
 	pixel_y = 3
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "eX" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "gf" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -310,6 +279,10 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "5-6"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "gB" = (
@@ -318,17 +291,19 @@
 	dir = 4;
 	id = "mudskipper_door"
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "gR" = (
 /obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
 	},
 /obj/structure/closet/crate/secure{
-	name = "scavenging supplies";
 	desc = "A secure crate. This one is particularly large.";
+	name = "scavenging supplies";
 	storage_capacity = 40
 	},
 /obj/item/reagent_containers/glass/chem_jug/thermite,
@@ -350,24 +325,28 @@
 /obj/item/multitool,
 /obj/item/stack/marker_beacon/thirty,
 /obj/item/gun/energy/plasmacutter,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "2-10"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "gT" = (
-/obj/structure/chair{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/plastic{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 6
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/walnut,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
+"hn" = (
+/turf/closed/wall/rust/yesdiag,
+/area/ship/external/dark)
 "hr" = (
 /obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -375,20 +354,20 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "hH" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/yesdiag,
 /area/ship/external/dark)
 "hX" = (
 /obj/structure/grille,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external/dark)
 "hY" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "ib" = (
@@ -401,66 +380,67 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/cargo)
 "ic" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-6"
 	},
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "iy" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "iY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-9"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/sign/poster/random{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
+/obj/structure/chair/handrail{
+	dir = 1
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
+"js" = (
+/turf/closed/wall/rust,
+/area/ship/bridge)
+"jz" = (
+/turf/closed/wall/rust,
+/area/ship/engineering/engine)
 "kB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "kV" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet/directional/west{
 	pixel_y = -5
 	},
 /obj/machinery/light/dim/directional/north,
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "kX" = (
@@ -468,33 +448,31 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/west{
 	bulb_power = 0.5
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "kY" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/cargo)
+"lg" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew/toilet)
 "lj" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull,
 /area/ship/engineering/engine)
 "ma" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -506,24 +484,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock{
-	name = "Bathroom"
+	dir = 1;
+	name = "Restroom"
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/toilet)
 "mC" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -533,10 +501,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/catwalk/over/plated_catwalk,
+/turf/open/floor/plating,
 /area/ship/hallway/central)
 "mF" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall/r_wall,
 /area/ship/cargo)
 "mS" = (
 /obj/structure/catwalk,
@@ -551,12 +520,12 @@
 	dir = 1;
 	id = "mudskipper_shield"
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "nj" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 28
 	},
@@ -569,60 +538,45 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "nm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair,
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 9
-	},
-/turf/open/floor/wood/walnut{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/plastic,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "nx" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/aft)
 "nM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/machinery/light/small/directional/north{
 	pixel_x = 6
 	},
 /obj/machinery/computer/helm/viewscreen/computer,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "nR" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "nV" = (
 /obj/structure/closet/wall/blue/directional/west{
-	secure = 1;
-	locked = 1
+	locked = 1;
+	secure = 1
 	},
 /obj/item/gun/energy/laser/scatter,
 /obj/item/stock_parts/cell/gun/upgraded,
@@ -640,66 +594,48 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ot" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/number/four{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "ov" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/photocopier,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "oC" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 4;
-	color = "#543C30"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "4-10"
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "oG" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -709,10 +645,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4;
+	name = "Office"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "oU" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/crew/toilet)
 "po" = (
 /obj/structure/catwalk,
@@ -726,7 +667,10 @@
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	id = "mudskipper_shield"
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "pF" = (
 /obj/machinery/firealarm/directional/west{
@@ -735,74 +679,72 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/reinforced,
 /obj/structure/bedsheetbin,
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "pY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/grimy,
-/area/ship/bridge)
-"qy" = (
-/obj/effect/turf_decal/corner/transparent/neutral{
-	dir = 4
-	},
-/obj/machinery/computer/crew{
-	dir = 8;
-	icon_state = "computer-right"
-	},
-/obj/machinery/button/door{
-	dir = 1;
-	pixel_x = -6;
-	pixel_y = -21;
-	name = "Bridge Lockdown";
-	id = "mudskipper_bridge"
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"qy" = (
+/obj/machinery/button/door{
+	dir = 1;
+	id = "mudskipper_bridge";
+	name = "Bridge Lockdown";
+	pixel_x = -6;
+	pixel_y = -21
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/obj/machinery/computer/crew/retro{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "qE" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "qN" = (
-/obj/machinery/cryopod,
-/obj/effect/turf_decal/techfloor{
-	dir = 10
+/obj/machinery/cryopod{
+	dir = 8
 	},
-/obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/north{
 	pixel_x = -3
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "rr" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 22;
 	pixel_y = -3
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"rG" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/toilet)
 "rO" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
@@ -812,15 +754,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "sa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5;
-	color = "#543C30"
-	},
 /obj/machinery/newscaster/directional/east{
 	pixel_y = -6
 	},
@@ -829,17 +766,20 @@
 	pixel_x = 22;
 	pixel_y = 5
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/plastic,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "sf" = (
-/obj/machinery/computer/helm{
-	dir = 8;
-	icon_state = "computer-left"
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
 	},
-/obj/effect/turf_decal/corner/transparent/neutral{
-	dir = 6
+/obj/effect/turf_decal/box,
+/obj/machinery/computer/helm/retro{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "sp" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer4{
@@ -849,33 +789,26 @@
 /obj/machinery/meter/atmos/layer2{
 	name = "waste to external meter"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "sA" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/effect/turf_decal/miskilamo_small/right{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/mono{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "sH" = (
 /obj/structure/catwalk,
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "sI" = (
-/obj/effect/turf_decal/techfloor,
 /obj/structure/railing{
 	dir = 8
 	},
@@ -891,42 +824,42 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/opaque/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "th" = (
-/obj/effect/turf_decal/borderfloor/full,
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/traffic,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ti" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/warning/incident{
 	pixel_x = -32
 	},
 /obj/machinery/computer/cargo/retro{
 	dir = 4
 	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "tI" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-6"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "tK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -937,23 +870,13 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "uk" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "uz" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/structure/railing{
@@ -963,17 +886,12 @@
 	pixel_x = 7;
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "uW" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Bridge";
-	req_one_access_txt = "20"
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
@@ -984,6 +902,15 @@
 	dir = 2;
 	id = "mudskipper_bridge"
 	},
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/command{
+	dir = 1;
+	name = "Bridge";
+	req_access_txt = "19"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "vn" = (
@@ -992,11 +919,11 @@
 /obj/structure/sign/poster/contraband/punch_shit{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "vI" = (
 /obj/structure/cable{
@@ -1008,10 +935,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
+"vP" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/bridge)
 "wi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -1023,25 +955,24 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "wj" = (
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "4-5"
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ws" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/engineering/engine)
 "xk" = (
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 25;
@@ -1049,6 +980,12 @@
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-14"
+	},
+/obj/structure/cable{
+	icon_state = "5-9"
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
@@ -1061,9 +998,7 @@
 	pixel_x = 22;
 	pixel_y = -6
 	},
-/turf/open/floor/wood/walnut{
-	icon_state = "wood-broken7"
-	},
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "xp" = (
 /obj/structure/toilet{
@@ -1071,39 +1006,32 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /obj/structure/curtain,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "xH" = (
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "xU" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/east{
 	bulb_power = 0.2
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
+"xZ" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/engineering/engine)
 "yg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet/directional/west{
 	pixel_y = -5
 	},
@@ -1115,24 +1043,23 @@
 	pixel_x = -22;
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "yv" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/cargo)
 "yB" = (
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "yS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -1141,10 +1068,14 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
+/area/ship/hallway/aft)
+"yV" = (
+/turf/closed/wall/r_wall/rust,
 /area/ship/hallway/aft)
 "yY" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/west{
 	bulb_power = 0.5
 	},
@@ -1152,63 +1083,65 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "zx" = (
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/door/poddoor/shutters{
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
 	dir = 4;
 	id = "mudskipper_engine"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "zR" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/grimy,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "zW" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
 "zX" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall/r_wall/rust,
 /area/ship/crew/cryo)
+"Ag" = (
+/turf/closed/wall/r_wall,
+/area/ship/hallway/aft)
 "Ak" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "AN" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
@@ -1217,9 +1150,6 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/light_switch{
@@ -1227,11 +1157,13 @@
 	pixel_x = 22;
 	pixel_y = -14
 	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Bj" = (
-/obj/effect/turf_decal/corner_techfloor_grid,
-/obj/effect/turf_decal/techfloor/corner,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/hacking_guide{
 	pixel_y = -32
@@ -1241,27 +1173,27 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Bn" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "Bw" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "BA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -1273,10 +1205,8 @@
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair/handrail,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "BW" = (
 /obj/effect/turf_decal/box,
@@ -1296,7 +1226,8 @@
 /obj/item/storage/pill_bottle/charcoal/less,
 /obj/item/reagent_containers/hypospray/medipen/penacid,
 /obj/item/reagent_containers/hypospray/medipen/penacid,
-/turf/open/floor/plasteel/tech,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Ch" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -1308,7 +1239,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "Cr" = (
 /obj/structure/table/reinforced,
@@ -1316,51 +1247,34 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
+"Cv" = (
+/turf/closed/wall/r_wall,
+/area/ship/maintenance)
 "CG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/suit/space/eva,
 /obj/item/clothing/head/helmet/space/eva,
 /obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
 "Dj" = (
-/obj/effect/turf_decal/borderfloor/full,
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/traffic,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/techmaint,
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Dp" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood/walnut{
-	icon_state = "wood-broken2"
-	},
-/area/ship/bridge)
-"DC" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
@@ -1371,59 +1285,66 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-9"
 	},
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"DA" = (
+/turf/closed/wall/r_wall,
+/area/ship/bridge)
+"DC" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "DS" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
+"DU" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew/cryo)
 "Ed" = (
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Eg" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/number/eight{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "Ey" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
@@ -1434,39 +1355,37 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-9"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet,
 /area/ship/crew)
 "EP" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/button/shieldwallgen{
 	dir = 1;
-	pixel_x = -6;
-	pixel_y = -21;
 	id = "mudskipper_shield";
-	name = "Cargo Holofield"
+	name = "Cargo Holofield";
+	pixel_x = -6;
+	pixel_y = -21
 	},
 /obj/machinery/button/door{
 	dir = 1;
-	pixel_x = 6;
-	pixel_y = -21;
 	id = "mudskipper_door";
-	name = "Cargo Door"
+	name = "Cargo Door";
+	pixel_x = 6;
+	pixel_y = -21
 	},
 /obj/effect/turf_decal/number/six{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plasteel/mono{
+	dir = 1
+	},
 /area/ship/cargo)
 "EQ" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -1475,19 +1394,21 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/north,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/hallway/aft)
 "Ft" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/structure/curtain/bounty,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -21;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = -21
 	},
-/turf/open/floor/wood/walnut,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "FN" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -1497,39 +1418,38 @@
 	},
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/light/engineer,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Gk" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "mudskipper_bridge"
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "Gq" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/crew)
 "GI" = (
 /obj/machinery/cryopod{
-	dir = 1
+	dir = 8
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 9
-	},
-/obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "GW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/walnut{
-	icon_state = "wood-broken7"
+/obj/structure/cable{
+	icon_state = "6-10"
 	},
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Hk" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
@@ -1539,37 +1459,29 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Id" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/item/stack/sheet/metal/five{
 	pixel_y = 3
 	},
 /obj/item/stack/sheet/glass/five{
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "IL" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "IP" = (
@@ -1588,18 +1500,17 @@
 	pixel_y = 3
 	},
 /obj/item/radio{
-	pixel_y = 3;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 3
 	},
 /obj/item/radio{
-	pixel_y = 3;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "IU" = (
-/obj/structure/catwalk,
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "JN" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
@@ -1608,14 +1519,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair/handrail,
+/turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/aft)
 "JS" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
@@ -1625,10 +1535,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Kt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -1637,14 +1546,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "KA" = (
 /obj/structure/window/reinforced/spawner,
 /obj/item/paper_bin,
 /obj/item/analyzer{
-	pixel_y = 3;
-	pixel_x = 13
+	pixel_x = 13;
+	pixel_y = 3
 	},
 /obj/item/pen,
 /obj/structure/cable{
@@ -1653,17 +1567,14 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "KT" = (
 /obj/machinery/washing_machine,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned,
 /area/ship/maintenance)
 "KU" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -1671,11 +1582,14 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
 "Lw" = (
 /obj/machinery/firealarm/directional/west{
@@ -1686,40 +1600,51 @@
 	pixel_x = -22;
 	pixel_y = -9
 	},
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/computer/cryopod/retro/directional/south,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
 "LV" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
+/area/ship/hallway/central)
+"LY" = (
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Mf" = (
 /turf/template_noop,
 /area/space)
 "Mi" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "MB" = (
@@ -1735,38 +1660,30 @@
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/door/window/eastright{
-	layer = 3.1
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/shutters{
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
 	dir = 4;
 	id = "mudskipper_engine"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "MK" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/maintenance)
+"Ne" = (
+/turf/closed/wall/rust,
+/area/ship/crew)
 "Ni" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Nj" = (
 /obj/machinery/door/airlock/external{
@@ -1778,12 +1695,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/aft)
 "Nl" = (
@@ -1791,7 +1703,7 @@
 	dir = 4
 	},
 /obj/machinery/light/floor,
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/cargo)
 "NJ" = (
 /obj/effect/turf_decal/box,
@@ -1813,51 +1725,49 @@
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /obj/item/reagent_containers/food/drinks/waterbottle,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "NN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "NU" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Oc" = (
 /obj/item/paper_bin,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/bottlegreen/full,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "OB" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/bridge)
 "OD" = (
-/obj/structure/chair{
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/plastic{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
+"OR" = (
+/turf/closed/wall/r_wall,
+/area/ship/crew)
 "Pr" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -1871,66 +1781,66 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/public/glass{
+	dir = 4;
+	name = "Canteen"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "PO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "PR" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "PU" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Qp" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/hallway/aft)
 "Qt" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "Qu" = (
 /obj/machinery/autolathe/hacked,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Qx" = (
 /obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-9"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "QF" = (
 /obj/machinery/power/terminal{
@@ -1938,10 +1848,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
@@ -1952,24 +1858,23 @@
 	},
 /obj/machinery/button/door{
 	dir = 1;
-	pixel_x = 6;
-	pixel_y = -21;
 	id = "mudskipper_window";
-	name = "Window Shutters"
+	name = "Window Shutters";
+	pixel_x = 6;
+	pixel_y = -21
 	},
 /obj/machinery/light/small/directional/west{
-	pixel_y = -6;
-	bulb_power = 0.6
+	bulb_power = 0.6;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Rl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 8
-	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = 10;
 	pixel_y = 5
@@ -1979,11 +1884,13 @@
 	pixel_y = 2
 	},
 /obj/item/paper/pamphlet{
+	name = "Salvage And You";
 	pixel_x = -3;
-	pixel_y = 2;
-	name = "Salvage And You"
+	pixel_y = 2
 	},
-/turf/open/floor/wood/walnut,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Rn" = (
 /obj/machinery/door/firedoor/border_only,
@@ -1995,15 +1902,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/grunge{
-	name = "Utility Closet"
+/obj/machinery/door/airlock{
+	name = "Custodial Closet"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/maintenance)
 "Rv" = (
 /obj/item/gps/mining{
-	pixel_y = 6;
-	gpstag = "SCAV0"
+	gpstag = "SCAV0";
+	pixel_y = 6
 	},
 /obj/item/clipboard{
 	pixel_x = 5;
@@ -2021,10 +1929,8 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "RR" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -2035,19 +1941,14 @@
 /obj/structure/filingcabinet/double,
 /obj/item/folder,
 /obj/machinery/light/small/directional/west{
-	pixel_y = 6;
-	bulb_power = 0.6
+	bulb_power = 0.6;
+	pixel_y = 6
 	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "So" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/door/airlock{
-	name = "Crew Quarters"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2057,7 +1958,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock{
+	name = "Dormitory"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Sq" = (
 /obj/structure/curtain,
@@ -2070,10 +1975,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/toilet)
 "ST" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/item/storage/cans/sixbeer,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/structure/closet/secure_closet/freezer{
@@ -2082,17 +1983,18 @@
 	},
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab,
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "Ti" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
 	name = "airlock waste injector"
 	},
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/engine/hull,
 /area/ship/external/dark)
 "Tn" = (
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2105,19 +2007,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "TV" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 4;
-	name = "Cargo Bay"
-	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -2133,7 +2026,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/obj/machinery/door/airlock/mining{
+	dir = 8;
+	name = "Cargo Bay"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Ud" = (
 /obj/effect/turf_decal/box,
@@ -2145,6 +2046,7 @@
 	pixel_y = -5
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/engine)
 "Ui" = (
@@ -2152,8 +2054,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"Uo" = (
+/turf/closed/wall/r_wall/yesdiag,
+/area/ship/crew/cryo)
 "UF" = (
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
@@ -2165,12 +2070,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -2180,7 +2079,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "UL" = (
 /obj/machinery/suit_storage_unit/inherit,
@@ -2188,6 +2088,10 @@
 /obj/machinery/light/directional/west,
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/light/engineer,
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "UZ" = (
@@ -2197,16 +2101,17 @@
 /obj/item/flashlight/lamp/green{
 	pixel_y = 4
 	},
-/turf/open/floor/wood/walnut,
+/obj/structure/cable{
+	icon_state = "5-6"
+	},
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "Vn" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/wrapping,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
+/obj/effect/turf_decal/corner/opaque/neutral/half,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Vo" = (
@@ -2217,11 +2122,6 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "Vy" = (
@@ -2230,38 +2130,23 @@
 /obj/structure/curtain/bounty,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/north,
-/turf/open/floor/wood/walnut,
+/turf/open/floor/plasteel/grimy,
 /area/ship/crew)
 "VP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-10"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "VW" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall,
 /area/ship/external/dark)
+"Wk" = (
+/turf/closed/wall/rust,
+/area/ship/maintenance)
 "Wm" = (
-/obj/machinery/door/airlock/grunge{
-	dir = 4;
-	name = "Cryogenic Storage"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -2271,7 +2156,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Cryo Room"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Wz" = (
 /obj/structure/sink{
@@ -2286,7 +2176,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "Xc" = (
 /obj/machinery/blackbox_recorder,
@@ -2294,35 +2184,46 @@
 /obj/machinery/light/small/directional/north{
 	pixel_x = -6
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "Xh" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
+/obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Xk" = (
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Xm" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
+"XI" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/cargo)
 "XK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
@@ -2331,26 +2232,22 @@
 	dir = 10
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "6-8"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "XU" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/plastic{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10;
-	color = "#543C30"
-	},
-/turf/open/floor/wood/walnut,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Yc" = (
 /obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
 /obj/item/gps/mining{
 	gpstag = "SCAV1"
@@ -2368,16 +2265,19 @@
 /obj/item/kitchen/knife/combat/survival,
 /obj/item/flashlight/seclite,
 /obj/item/flashlight/seclite,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Yd" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters{
 	id = "mudskipper_window"
 	},
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ship/crew)
+"Yi" = (
+/turf/closed/wall/r_wall/yesdiag,
+/area/ship/maintenance)
 "Yq" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor4"
@@ -2387,45 +2287,40 @@
 	target_pressure = 1000
 	},
 /obj/machinery/atmospherics/components/binary/volume_pump/layer2{
-	name = "Scrubbers to External";
-	dir = 1
+	dir = 1;
+	name = "Scrubbers to External"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering/engine)
+"Yu" = (
+/turf/closed/wall/r_wall,
 /area/ship/engineering/engine)
 "Yv" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/machinery/firealarm/directional/east{
 	pixel_y = -5
 	},
 /obj/machinery/light/dim/directional/north,
+/obj/effect/turf_decal/corner/opaque/neutral/half,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "YK" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-9"
 	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/corner/transparent/beige/full,
+/obj/effect/turf_decal/corner/transparent/brown/diagonal,
+/obj/structure/chair/handrail{
+	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "YL" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
@@ -2435,7 +2330,6 @@
 /area/ship/engineering/engine)
 "Zi" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 8
 	},
@@ -2443,39 +2337,33 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
+/obj/structure/catwalk/over/plated_catwalk,
 /turf/open/floor/plating,
 /area/ship/cargo)
+"Zx" = (
+/turf/closed/wall/r_wall/rust,
+/area/ship/crew)
 "ZC" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30";
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet,
 /area/ship/crew)
 "ZJ" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 
 (1,1,1) = {"
@@ -2490,7 +2378,7 @@ ag
 ag
 lj
 ag
-ws
+jz
 cs
 cs
 cs
@@ -2501,16 +2389,16 @@ cs
 cs
 hX
 IU
-ws
-ws
-bZ
-zx
-bZ
+Yu
+Yu
 MF
 zx
 MF
-ws
-ws
+MF
+zx
+MF
+xZ
+Yu
 IU
 hX
 cs
@@ -2520,7 +2408,7 @@ cs
 cs
 hX
 cs
-ws
+Yu
 kX
 QF
 en
@@ -2529,7 +2417,7 @@ Vo
 qE
 ao
 yY
-ws
+Yu
 cs
 hX
 cs
@@ -2548,7 +2436,7 @@ KA
 eu
 hY
 sI
-ws
+Yu
 IU
 hX
 hX
@@ -2558,7 +2446,7 @@ cs
 hX
 cs
 cs
-ws
+xZ
 Ud
 Hk
 AN
@@ -2567,7 +2455,7 @@ dw
 hr
 xU
 YL
-ws
+Yu
 cs
 cs
 hX
@@ -2576,18 +2464,18 @@ cs
 (6,1,1) = {"
 hX
 IU
-OB
-OB
+DA
+DA
 OB
 UF
 OB
+js
+js
 OB
-OB
-OB
-OB
+js
 Qp
-Qp
-Qp
+Ag
+Ag
 Ti
 hX
 cs
@@ -2595,7 +2483,7 @@ cs
 (7,1,1) = {"
 cs
 cs
-OB
+DA
 Xc
 ic
 ak
@@ -2614,7 +2502,7 @@ cs
 (8,1,1) = {"
 cs
 cs
-OB
+DA
 Rv
 Oc
 Dp
@@ -2633,18 +2521,18 @@ MB
 (9,1,1) = {"
 cs
 cs
-OB
+vP
 nM
 rr
 oC
-OB
+js
 dN
 sf
 qy
 OB
 JN
 CG
-Qp
+Ag
 IU
 cs
 cs
@@ -2652,8 +2540,8 @@ cs
 (10,1,1) = {"
 hX
 IU
-OB
-OB
+DA
+DA
 OB
 oG
 OB
@@ -2662,8 +2550,8 @@ Gk
 Gk
 OB
 Nj
-Qp
-Qp
+yV
+Ag
 IU
 hX
 cs
@@ -2710,7 +2598,7 @@ cs
 hX
 cs
 cs
-Qp
+Ag
 sT
 vn
 Qp
@@ -2719,7 +2607,7 @@ ar
 sa
 eL
 gT
-Qp
+Ag
 cs
 cs
 hX
@@ -2728,9 +2616,9 @@ cs
 (14,1,1) = {"
 hX
 IU
-Gq
-Gq
-Gq
+OR
+OR
+Ne
 Gq
 Gq
 dc
@@ -2738,8 +2626,8 @@ Pr
 dc
 oU
 oU
-oU
-oU
+rG
+rG
 IU
 hX
 cs
@@ -2747,7 +2635,7 @@ cs
 (15,1,1) = {"
 cs
 cs
-Gq
+OR
 Vy
 UZ
 Ft
@@ -2758,7 +2646,7 @@ Xh
 oU
 kB
 xp
-oU
+rG
 cs
 cs
 cs
@@ -2777,7 +2665,7 @@ Qx
 mt
 Ch
 Wz
-oU
+lg
 cs
 cs
 cs
@@ -2789,14 +2677,14 @@ Yd
 xo
 cB
 dQ
-Gq
+Ne
 DS
 Mi
 ZJ
 oU
 tK
 Sq
-oU
+lg
 IU
 hX
 cs
@@ -2804,18 +2692,18 @@ cs
 (18,1,1) = {"
 hX
 cs
-Gq
+Zx
 Gq
 Wm
 Gq
-Gq
-dc
+Ne
+LY
 mC
 iY
 MK
 MK
-MK
-MK
+Wk
+Cv
 cs
 hX
 cs
@@ -2827,14 +2715,14 @@ zX
 KU
 zW
 Lw
-zX
+ev
 Vn
 DC
 PO
 Rn
 wi
 pF
-MK
+Cv
 cs
 hX
 cs
@@ -2842,18 +2730,18 @@ cs
 (20,1,1) = {"
 hX
 IU
-zX
+DU
 qN
 IP
 GI
-zX
+ev
 Yv
 LV
 xk
 MK
 cn
 KT
-MK
+Cv
 IU
 hX
 cs
@@ -2861,18 +2749,18 @@ cs
 (21,1,1) = {"
 cs
 cs
-zX
-zX
-zX
-zX
-zX
+Uo
+DU
+ev
+ev
+ev
 dc
 TV
 dc
 MK
 MK
-MK
-MK
+Cv
+Yi
 cs
 cs
 cs
@@ -2939,7 +2827,7 @@ cs
 hX
 IU
 mF
-mF
+XI
 uz
 gR
 Xk
@@ -2984,7 +2872,7 @@ gB
 gB
 gB
 mS
-mF
+XI
 IU
 IU
 hX
@@ -2996,7 +2884,7 @@ cs
 cs
 cs
 VW
-hH
+hn
 Nl
 kY
 ib
@@ -3034,14 +2922,14 @@ cs
 cs
 cs
 cs
-hH
-hH
+hn
+hn
 cs
 cs
 cs
 cs
 hH
-hH
+hn
 cs
 cs
 cs
@@ -3059,7 +2947,7 @@ cs
 cs
 cs
 cs
-hH
+hn
 cs
 cs
 cs

--- a/_maps/shuttles/independent/independent_shetland.dmm
+++ b/_maps/shuttles/independent/independent_shetland.dmm
@@ -131,11 +131,17 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "bm" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
@@ -169,6 +175,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/chair/handrail,
 /turf/open/floor/plating,
 /area/ship/hallway/fore)
 "bD" = (
@@ -244,7 +251,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "cD" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -336,6 +343,9 @@
 /obj/structure/cable{
 	icon_state = "5-9"
 	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "cR" = (
@@ -422,6 +432,7 @@
 	pixel_x = -20;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "dT" = (
@@ -461,6 +472,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/trash/candy,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "en" = (
@@ -475,6 +487,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "es" = (
@@ -512,7 +525,7 @@
 "ez" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/computer/helm/viewscreen/directional/east,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "eC" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
@@ -700,6 +713,9 @@
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/starboard)
 "gc" = (
@@ -764,6 +780,9 @@
 "gt" = (
 /obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "gF" = (
@@ -838,7 +857,6 @@
 /area/ship/hallway/fore)
 "hp" = (
 /obj/structure/table,
-/obj/machinery/computer/cryopod/directional/west,
 /obj/machinery/newscaster/directional/south,
 /obj/item/cigbutt{
 	pixel_x = -10;
@@ -846,6 +864,7 @@
 	},
 /obj/item/cigbutt,
 /obj/item/reagent_containers/food/snacks/chips,
+/obj/machinery/computer/cryopod/retro/directional/west,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/cryo)
 "hv" = (
@@ -983,6 +1002,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel,
 /area/ship/hallway/port)
 "is" = (
@@ -1076,6 +1096,9 @@
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "jj" = (
@@ -1127,6 +1150,7 @@
 /obj/effect/turf_decal/corner/opaque/bottlegreen/full,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "jC" = (
@@ -1182,7 +1206,7 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/engine/hull/interior,
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "jY" = (
 /turf/closed/wall,
@@ -1233,6 +1257,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plating,
 /area/ship/hallway/starboard)
 "ki" = (
@@ -1241,6 +1266,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/port)
 "kt" = (
@@ -1590,6 +1618,9 @@
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
 "of" = (
@@ -1724,6 +1755,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "ph" = (
@@ -1757,6 +1791,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/vomit/old,
+/mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "pI" = (
@@ -1841,6 +1876,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 1
 	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "qa" = (
@@ -1850,7 +1888,8 @@
 "qb" = (
 /obj/structure/crate_shelf,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "qg" = (
 /obj/structure/closet/secure_closet/engineering_personal{
@@ -1937,6 +1976,9 @@
 	pixel_y = -20
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2196,7 +2238,10 @@
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/borderfloor{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "su" = (
 /obj/structure/disposalpipe/segment,
@@ -2420,6 +2465,9 @@
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "uM" = (
@@ -2428,6 +2476,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4{
 	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
@@ -2452,6 +2503,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel,
 /area/ship/hallway/starboard)
 "va" = (
@@ -2530,6 +2582,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
+"vL" = (
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "vN" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable/yellow{
@@ -2561,6 +2619,9 @@
 "vV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/item/kirbyplants/fullysynthetic,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/blue,
 /area/ship/bridge)
 "vX" = (
@@ -2688,6 +2749,9 @@
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "amogusthrusters"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
@@ -2927,6 +2991,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "yP" = (
@@ -2964,6 +3029,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/security)
 "yY" = (
@@ -3107,7 +3176,8 @@
 /obj/effect/turf_decal/box,
 /obj/item/tank/internals/oxygen/red,
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/borderfloor,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Ab" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -3156,7 +3226,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "Ax" = (
 /obj/structure/table/wood,
@@ -3346,6 +3416,9 @@
 "CF" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/port)
 "CH" = (
@@ -3414,7 +3487,10 @@
 /obj/item/pickaxe,
 /obj/effect/turf_decal/box,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Dm" = (
 /obj/machinery/cryopod{
@@ -3546,6 +3622,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/atmospherics)
 "EA" = (
@@ -3631,6 +3708,9 @@
 /area/ship/crew/janitor)
 "ER" = (
 /obj/effect/turf_decal/industrial/warning,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/hallway/starboard)
 "EX" = (
@@ -3643,6 +3723,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "FE" = (
@@ -3672,7 +3753,7 @@
 	id = "amogusdoors";
 	name = "Cargo Bay Blast Door"
 	},
-/turf/open/floor/engine/hull/interior,
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "Gg" = (
 /obj/machinery/light/dim/directional/south,
@@ -3699,7 +3780,10 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/head/hardhat/mining,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/borderfloor{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Gt" = (
 /obj/effect/turf_decal/corner/opaque/neutral/three_quarters{
@@ -3711,6 +3795,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 24
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "Gw" = (
@@ -3973,6 +4058,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "IE" = (
@@ -3981,6 +4067,9 @@
 	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -21
+	},
+/obj/structure/chair/handrail{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/starboard)
@@ -4116,6 +4205,9 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1{
 	dir = 9
 	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/aft)
 "JQ" = (
@@ -4194,6 +4286,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/ship/hallway/central)
 "Kq" = (
@@ -4260,6 +4355,17 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/engine/vacuum,
 /area/ship/engineering/engine)
+"Li" = (
+/obj/structure/bed,
+/obj/structure/curtain/bounty,
+/obj/item/bedsheet/dorms,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ship/crew/dorm)
 "Ll" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4318,6 +4424,9 @@
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "amogusthrusters"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
@@ -4437,6 +4546,9 @@
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
+"Mf" = (
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "Mk" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -4444,6 +4556,13 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
+"Ml" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/starboard)
 "Mr" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -4531,9 +4650,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
-"MV" = (
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
 "Na" = (
 /turf/closed/wall/rust,
 /area/ship/crew/canteen)
@@ -4548,13 +4664,17 @@
 "Ne" = (
 /obj/structure/crate_shelf,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Ni" = (
 /obj/structure/bed,
 /obj/structure/curtain/bounty,
 /obj/item/bedsheet/dorms,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "Nl" = (
@@ -4613,6 +4733,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "NR" = (
@@ -4870,6 +4991,9 @@
 	dir = 4;
 	id = "amogusthrusters"
 	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/port)
 "PR" = (
@@ -4952,6 +5076,15 @@
 	},
 /turf/open/floor/plating,
 /area/ship/hallway/fore)
+"Qu" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/hallway/port)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -5026,6 +5159,9 @@
 	dir = 4;
 	id = "amogusthrusters"
 	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "Ri" = (
@@ -5087,6 +5223,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ship/hallway/port)
 "Ry" = (
@@ -5292,7 +5431,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Tk" = (
 /obj/structure/cable{
@@ -5318,7 +5457,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "TO" = (
 /obj/machinery/firealarm/directional/south,
@@ -5358,6 +5497,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "TX" = (
@@ -5377,6 +5517,9 @@
 /obj/effect/turf_decal/corner/transparent/beige/full,
 /obj/effect/turf_decal/corner/transparent/brown/diagonal,
 /obj/machinery/light/directional/west,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Ug" = (
@@ -5421,7 +5564,7 @@
 /turf/open/floor/plating,
 /area/ship/hallway/aft)
 "UJ" = (
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "UT" = (
 /obj/machinery/recharger,
@@ -5495,6 +5638,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
 "VN" = (
@@ -5532,6 +5676,9 @@
 /area/ship/engineering/engine)
 "VS" = (
 /obj/machinery/light/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/fore)
 "VV" = (
@@ -5556,7 +5703,8 @@
 /obj/structure/cable{
 	icon_state = "1-6"
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "We" = (
 /turf/closed/wall/r_wall/rust/yesdiag,
@@ -5585,7 +5733,8 @@
 /obj/structure/crate_shelf,
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/patterned/grid,
 /area/ship/cargo)
 "Wq" = (
 /obj/structure/grille,
@@ -5609,7 +5758,7 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/turf/open/floor/engine/hull/interior,
+/turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)
 "Ws" = (
 /obj/effect/turf_decal/corner/transparent/beige/full,
@@ -5632,6 +5781,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/toilet)
 "WB" = (
@@ -5650,6 +5802,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/cryo)
 "WG" = (
@@ -5662,6 +5817,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plating,
 /area/ship/engineering/electrical)
 "WM" = (
@@ -5684,6 +5840,9 @@
 /area/ship/bridge)
 "Xg" = (
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
 "Xh" = (
@@ -5741,6 +5900,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "XJ" = (
@@ -5749,6 +5911,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/structure/chair/handrail,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "XK" = (
@@ -5950,6 +6113,10 @@
 	dir = 8
 	},
 /obj/structure/curtain,
+/obj/structure/sign/poster/random{
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "ZJ" = (
@@ -5958,8 +6125,8 @@
 	},
 /obj/structure/curtain,
 /obj/item/soap,
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 1
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 9
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew/toilet)
@@ -6483,7 +6650,7 @@ fz
 "}
 (18,1,1) = {"
 BL
-bm
+Qu
 CF
 XY
 we
@@ -6505,7 +6672,7 @@ sk
 RP
 rJ
 pY
-ER
+Ml
 iG
 OU
 "}
@@ -6640,7 +6807,7 @@ Gy
 ND
 jY
 Kn
-ZV
+vL
 rr
 fW
 fW
@@ -6808,7 +6975,7 @@ aI
 aI
 aI
 iz
-ZV
+vL
 rr
 sX
 su
@@ -6849,7 +7016,7 @@ OU
 ao
 Ok
 uh
-Ni
+Li
 mJ
 mJ
 mJ
@@ -6922,7 +7089,7 @@ gq
 wQ
 MT
 pl
-MV
+Mf
 xZ
 qO
 CH


### PR DESCRIPTION
space: Cherry-picking commits from shiptest proper. Dunno if you want this one, up to you and if the ✨aesthetics✨ bring you joy

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![mudskipper](https://github.com/user-attachments/assets/85d29f5d-ed85-48a9-ac6f-aa1d485b0416)

![kilo](https://github.com/user-attachments/assets/32e04076-29e0-438b-a212-4649de4d4abf)

![shetland](https://github.com/user-attachments/assets/57f46122-4ba8-4140-b003-a3a3ac3bec75)

- Re-palettes the Mudskipper, Kilo, and Shetland for aesthetic consistency across the Miskilamo ships
- Changes Mudskipper to use the same cheap captain outfit as shetland and kilo
- Cuts Kilo's starting funds to 1500, same as Shetland
- fixes Mudskipper's wires :)

## Why It's Good For The Game

Manufacturer consistency good and kilo had a bit too much money