### PR TITLE
kilo remap fixes (#3424)

### DIFF
--- a/_maps/shuttles/independent/independent_kilo.dmm
+++ b/_maps/shuttles/independent/independent_kilo.dmm
@@ -22,6 +22,9 @@
 	dir = 4;
 	id = "kilothrusters"
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
 /area/ship/engineering)
 "av" = (
@@ -1581,6 +1584,9 @@
 	dir = 4;
 	id = "kilothrusters"
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ship/engineering)
 "MY" = (
@@ -1890,7 +1896,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/button/door{
 	dir = 8;
-	id = "amogusthrusters";
+	id = "kilothrusters";
 	name = "Thruster Lockdown";
 	pixel_x = 21
 	},


### PR DESCRIPTION
space - cherry-picking PRs from shiptest proper. Feel free to merge or not as it suits.

***

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Kilo remap was good, asides the fact there was not a reinforced window on the thrusters to stop it being spaced if you open the blast doors. However, this problem was self-solving as the blast doors were not connected to the new button.

This fixes both issues by adding windows to the thrusters, and linking the button correctly.

![image](https://github.com/user-attachments/assets/852855b1-98a7-4850-bf05-f327c809913e)

![image](https://github.com/user-attachments/assets/1066b7e4-5bb2-41dd-be5f-aa1101df9a00)


## Changelog

:cl:
fix: Fixed the lack of windows for the Kilo's Thrusters, and fixed the broken link for the new blast doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->