### PR TITLE
Cyborgs Rejoice

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -247,6 +247,14 @@
 	build_path = /obj/item/clothing/ears/earmuffs
 	category = list("initial", "Misc")
 
+/datum/design/shipaccesschip
+	name = "Ship Access Chip"
+	id = "ship_access_chip"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 500)
+	build_path = /obj/item/borg/upgrade/ship_access_chip
+	category = list("initial", "Misc")
+
 /datum/design/pipe_painter
 	name = "Pipe Painter"
 	id = "pipe_painter"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -58,6 +58,7 @@
 	research_icon_state = "borg_r_leg"
 	build_path = /obj/item/bodypart/leg/right/robot
 	materials = list(/datum/material/iron=10000)
+	construction_time = 200
 
 
 //Prosthetics


### PR DESCRIPTION
Cyborg ship access chips now are craftable in the autolathe at round start!

Small change for uniformity: Did you know the cyborg right leg had no build time unlike the rest? Now it does!