### PR TITLE
split botany crates

### DIFF
--- a/code/modules/cargo/packs/civilian.dm
+++ b/code/modules/cargo/packs/civilian.dm
@@ -50,26 +50,6 @@
 	crate_type = /obj/structure/closet/crate/large
 
 /*
-		Hydroponics
-*/
-
-/datum/supply_pack/civilian/MegaSeed
-	name = "MegaSeed Vending Machine"
-	desc = "A vending machine full of seeds"
-	cost = 800
-	contains = list(/obj/machinery/vending/hydroseeds)
-	crate_name = "MegaSeed vending machine crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/civilian/NutriMax
-	name = "NutriMax Vending Machine"
-	desc = "A vending machine full of nutrients"
-	cost = 800
-	contains = list(/obj/machinery/vending/hydronutrients)
-	crate_name = "NutriMax vending machine crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/*
 		Bundles
 */
 

--- a/code/modules/cargo/packs/vendor_refill.dm
+++ b/code/modules/cargo/packs/vendor_refill.dm
@@ -46,11 +46,18 @@
 	crate_name = "games supply crate"
 
 /datum/supply_pack/vendor_refill/hydroponics
-	name = "Hydroponics Supply Crate"
-	desc = "Out of seeds? Out of nutrients? No worries! This crate contains refills for the MegaSeed and Nutrimax"
-	cost = 1000
+	name = "Hydroponics Nutrient Crate"
+	desc = "Need some variety in your crop rotation? Contains a vending refill, to build or restock a MegaSeed servitor"
+	cost = 3000
 	contains = list(/obj/item/vending_refill/hydroseeds,
 					/obj/item/vending_refill/hydronutrients)
+	crate_name = "hydroponics supply crate"
+
+/datum/supply_pack/vendor_refill/hydroponics_nutrients
+	name = "Hydroponics Nutrient Restock"
+	desc = "Out of nutrients? Contains a vending refill for building or restocking a Nutrimax vending machine."
+	cost = 1500
+	contains = list(/obj/item/vending_refill/hydronutrients)
 	crate_name = "hydroponics supply crate"
 
 /datum/supply_pack/vendor_refill/mining_equipment


### PR DESCRIPTION
splits the botany refill and nutrient refill crate and rebalances their pricing. removes the full machine as you can already make em from vendor boards.