### PR TITLE
Added stethoscope to autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -610,6 +610,14 @@
 	build_path = /obj/item/reagent_containers/glass/chem_jug/open
 	category = list("initial", "Medical", "Medical Designs")
 
+/datum/design/stethoscope
+	name = "Stethoscope"
+	id = "stethoscope"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1000, /datum/material/plastic = 250)
+	build_path = /obj/item/clothing/neck/stethoscope
+	category = list("initial", "Medical", "Medical Designs")
+
 /datum/design/recorder
 	name = "Universal Recorder"
 	id = "recorder"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds stethoscope to autolathe. Material costs defined as the following, somewhat freehanded from the costs of other medical tools:

Iron: 5000
Glass: 1000
Plastic: 250

## Why It's Good For The Game

Stethoscopes are weirdly rare for a 'primitive medical tool that's hardly used anymore'; essentially the only ways to obtain one are to either spawn with one as a doctor, or to find one out in a ruin somewhere. It's not represented in any research or otherwise printable via either the protolathe or the autolathe.  This presents a problem, as there are some ruins that generate with safes which just flatly can't be opened or dragged along to be accessed later.

There is still a bit of friction to obtaining one; besides the stethoscope having a cost similar to medical tools that ARE locked behind research, I also threw in a small plastic cost (rubber hoses on stethoscope!) to act as at least a small barrier to entry that isn't research-dependent. Safe-opening for the people! 

## Changelog

:cl: MissyNym
add: adds stethoscope to the autolathe as a printable object
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
