### PR TITLE
Surplus calibur ammo

### DIFF
--- a/code/modules/cargo/packs/ammo.dm
+++ b/code/modules/cargo/packs/ammo.dm
@@ -33,7 +33,7 @@
 
 /datum/supply_pack/ammo/m10mm_mag
 	name = "10mm ringneck Magazine Crate"
-	desc = "Contains a 10mm magazine for the ringneck pistol, containing ten rounds."
+	desc = "Contains a 10mm magazine for the ringneck pistol, containing eight rounds."
 	contains = list(/obj/item/ammo_box/magazine/m10mm_ringneck)
 	cost = 500
 

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_box/magazine/m10mm_ringneck/rifle
 	name = "rifle magazine (10mm)"
-	desc = "A well-worn, 10-round magazine for the surplus rifle. These rounds do moderate damage, but struggle against armor."
+	desc = "A well-worn, 8-round magazine for the surplus rifle. These rounds do moderate damage, but struggle against armor."
 	icon_state = "75-8"
 	base_icon_state = "75"
 	ammo_type = /obj/item/ammo_casing/c10mm

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -58,7 +58,7 @@
 
 /obj/item/ammo_box/magazine/smgm10mm
 	name = "Mongrel magazine (10mm)"
-	desc = "A 24-round magazine for the SKM-44v. These rounds do moderate damage, but struggle against armor."
+	desc = "A 20-round magazine for the SKM-44v. These rounds do moderate damage, but struggle against armor."
 	icon_state = "mongrel_mag-24"
 	base_icon_state = "mongrel_mag"
 	ammo_type = /obj/item/ammo_casing/c10mm

--- a/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/clip_lanchester/ballistics.dm
@@ -1,7 +1,7 @@
 //########### PISTOLS ###########//
 /obj/item/gun/ballistic/automatic/pistol/cm23
 	name = "\improper CM-23"
-	desc = "CLIP's standard service pistol. 10 rounds of 10mm ammunition make the CM-23 deadlier than many other service pistols, but its weight and bulk have made it unpopular as a sidearm. It has largely been phased out outside of specialized units and patrols on the fringes of CLIP space. Chambered in 10mm."
+	desc = "CLIP's standard service pistol. 8 rounds of 10mm ammunition make the CM-23 deadlier than many other service pistols, but its weight and bulk have made it unpopular as a sidearm. It has largely been phased out outside of specialized units and patrols on the fringes of CLIP space. Chambered in 10mm."
 	icon = 'icons/obj/guns/manufacturer/clip_lanchester/48x32.dmi'
 	lefthand_file = 'icons/obj/guns/manufacturer/clip_lanchester/lefthand.dmi'
 	righthand_file = 'icons/obj/guns/manufacturer/clip_lanchester/righthand.dmi'

--- a/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
+++ b/code/modules/projectiles/guns/manufacturer/scarborough/ballistics.dm
@@ -79,7 +79,7 @@ EMPTY_GUN_HELPER(automatic/pistol/ringneck/indie)
 
 /obj/item/ammo_box/magazine/m10mm_ringneck
 	name = "Ringneck pistol magazine (10mm)"
-	desc = "An 10-round magazine for the Ringneck pistol. These rounds do moderate damage, but struggle against armor."
+	desc = "An 8-round magazine for the Ringneck pistol. These rounds do moderate damage, but struggle against armor."
 	icon_state = "ringneck_mag-1"
 	base_icon_state = "ringneck_mag"
 	ammo_type = /obj/item/ammo_casing/c10mm

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -3,11 +3,12 @@
 /obj/projectile/bullet/c9mm
 	name = "9mm bullet"
 	damage = 20
-	armour_penetration = -20
+	armour_penetration = -15
 
 /obj/projectile/bullet/c9mm/surplus
 	name = "9mm surplus bullet"
 	damage = 15
+	armour_penetration = -25
 
 /obj/projectile/bullet/c9mm/ap
 	name = "9mm armor-piercing bullet"
@@ -36,11 +37,12 @@
 /obj/projectile/bullet/c10mm
 	name = "10mm bullet"
 	damage = 30
-	armour_penetration = -20
+	armour_penetration = -10
 
 /obj/projectile/bullet/c10mm/surplus
 	name = "10mm surplus bullet"
 	damage = 25
+	armour_penetration = -20
 
 /obj/projectile/bullet/c10mm/ap
 	name = "10mm armor-piercing bullet"
@@ -69,11 +71,12 @@
 /obj/projectile/bullet/c45
 	name = ".45 bullet"
 	damage = 25
-	armour_penetration = -20
+	armour_penetration = -10
 
 /obj/projectile/bullet/c45/surplus
 	name = ".45 surplus bullet"
 	damage = 20
+	armour_penetration = -20
 
 /obj/projectile/bullet/c45/ap
 	name = ".45 armor-piercing bullet"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -14,10 +14,11 @@
 /obj/projectile/bullet/c38
 	name = ".38 bullet"
 	damage = 20
-	armour_penetration = -20
+	armour_penetration = -10
 
 /obj/projectile/bullet/c38/surplus
 	damage = 15
+	armour_penetration = -20
 
 /obj/projectile/bullet/c38/match
 	name = ".38 match bullet"


### PR DESCRIPTION

## Changelog

Added additional balancing for surplus vs normal ammo

balance: Added Armour_penetration stat to surplus ammo - Buffed normal ammo armour_pen to compensate

spellcheck: Changed descriptions of 10mm magazines to use their new sizes
